### PR TITLE
Adds cdash_analyze_and_report.py --filter-out-builds-and-tests-not-matching-expected-builds, fix filtering

### DIFF
--- a/test/ci_support/CDashQueryAnalyzeReport_UnitTests.py
+++ b/test/ci_support/CDashQueryAnalyzeReport_UnitTests.py
@@ -1700,7 +1700,7 @@ class test_AddIssueTrackerInfoToTestDictFunctor(unittest.TestCase):
 
 #############################################################################
 #
-# Test CDashQueryAnalyzeReport.testsWithIssueTrackersMatchExpectedBuilds()
+# Test CDashQueryAnalyzeReport.doTestsWithIssueTrackersMatchExpectedBuilds()
 #
 #############################################################################
 
@@ -1722,13 +1722,13 @@ g_testsWtihIssueTrackersLOD = [
   sbtiturlit('site2', 'build2', 'test5', 'url5', '#1114'),
   ]
 
-class test_testsWithIssueTrackersMatchExpectedBuilds(unittest.TestCase):
+class test_doTestsWithIssueTrackersMatchExpectedBuilds(unittest.TestCase):
 
   def test_all_match(self):
     testToExpectedBuildsSLOD = \
       createTestToBuildSearchableListOfDicts(g_expectedBuildsLOD)
     self.assertEqual(
-      testsWithIssueTrackersMatchExpectedBuilds(
+      doTestsWithIssueTrackersMatchExpectedBuilds(
         g_testsWtihIssueTrackersLOD, testToExpectedBuildsSLOD),
       (True, "")
       )
@@ -1738,7 +1738,7 @@ class test_testsWithIssueTrackersMatchExpectedBuilds(unittest.TestCase):
     testToExpectedBuildsSLOD = \
       createTestToBuildSearchableListOfDicts(g_expectedBuildsLOD)
     testsWtihIssueTrackersLOD[1]['buildName'] = 'build8'
-    (matches, errMsg) = testsWithIssueTrackersMatchExpectedBuilds(
+    (matches, errMsg) = doTestsWithIssueTrackersMatchExpectedBuilds(
       testsWtihIssueTrackersLOD, testToExpectedBuildsSLOD)
     self.assertEqual(matches, False)
     self.assertEqual(errMsg,
@@ -1752,7 +1752,7 @@ class test_testsWithIssueTrackersMatchExpectedBuilds(unittest.TestCase):
       createTestToBuildSearchableListOfDicts(g_expectedBuildsLOD)
     testsWtihIssueTrackersLOD[1]['buildName'] = 'build8'
     testsWtihIssueTrackersLOD[3]['site'] = 'site3'
-    (matches, errMsg) = testsWithIssueTrackersMatchExpectedBuilds(
+    (matches, errMsg) = doTestsWithIssueTrackersMatchExpectedBuilds(
       testsWtihIssueTrackersLOD, testToExpectedBuildsSLOD)
     self.assertEqual(matches, False)
     self.assertEqual(errMsg,

--- a/test/ci_support/cdash_analyze_and_report_UnitTests.py
+++ b/test/ci_support/cdash_analyze_and_report_UnitTests.py
@@ -259,7 +259,9 @@ class test_cdash_analyze_and_report(unittest.TestCase):
     cdash_analyze_and_report_run_case(
       self,
       testCaseName,
-      ["--print-details=on"],  # grep for verbose output
+      [ "--print-details=on", # grep for verbose output
+        "--limit-table-rows=20", # Let's see all of the twoif tets!
+        ],
       1,
       "FAILED (twoif=12, twif=9): ProjectName Nightly Builds on 2018-10-28",
       [
@@ -310,7 +312,7 @@ class test_cdash_analyze_and_report(unittest.TestCase):
         "</p>",
          
         # twoif table
-        "<h3><font color=\"red\">Tests without issue trackers Failed [(]limited to 10[)]: twoif=12</font></h3>",
+        "<h3><font color=\"red\">Tests without issue trackers Failed [(]limited to 20[)]: twoif=12</font></h3>",
         # Pin down table headers
         "<th>Site</th>",
         "<th>Build Name</th>",
@@ -362,6 +364,7 @@ class test_cdash_analyze_and_report(unittest.TestCase):
       [
         "--expected-builds-file=",
         "--tests-with-issue-trackers-file=",
+        "--limit-table-rows=30", # Let's see all of the twoif tets!
         ],
       1,
       "FAILED (twoif=21): ProjectName Nightly Builds on 2018-10-28",
@@ -404,7 +407,7 @@ class test_cdash_analyze_and_report(unittest.TestCase):
         "</p>",
          
         # twoif table
-        "<h3><font color=\"red\">Tests without issue trackers Failed [(]limited to 10[)]: twoif=21</font></h3>",
+        "<h3><font color=\"red\">Tests without issue trackers Failed [(]limited to 30[)]: twoif=21</font></h3>",
         ],
       #verbose=True,
       #debugPrint=True,
@@ -1741,7 +1744,7 @@ cee-rhel6, Trilinos-atdm-cee-rhel6-gnu-4.9.3-opt-serial, PanzerAdaptersIOSS_tIOS
   #
   def test_twoif_2_twif_4_filter_based_on_expected_builds(self):
 
-    testCaseName = "test_twoif_2_twif_4_filter_based_on_expected_builds"
+    testCaseName = "twoif_2_twif_4_filter_based_on_expected_builds"
 
     testOutputDir = cdash_analyze_and_report_setup_test_dir(testCaseName)
 

--- a/test/ci_support/cdash_analyze_and_report_UnitTests.py
+++ b/test/ci_support/cdash_analyze_and_report_UnitTests.py
@@ -1477,7 +1477,7 @@ class test_cdash_analyze_and_report(unittest.TestCase):
   # Test to check that when only 'twip' and 'twim' exists, then we consider
   # this to be global PASSED.
   #
-  # We use test rseults that exist in the directory twoif_12_twif_9/ to create
+  # We use test results that exist in the directory twoif_12_twif_9/ to create
   # these cases.  We copy out and modify the test dicts that we want, modify
   # them to be passing and missing tests, then write then back to the file
   # fullCDashNonpassingTests.json
@@ -1494,7 +1494,8 @@ class test_cdash_analyze_and_report(unittest.TestCase):
       testOutputDir+"/ProjectName_Nightly_Builds_fullCDashNonpassingTests.json"
     CDQAR.pprintPythonDataToFile( {'builds':[]}, testListFilePath )
 
-    # Write a new tests with issue trackers file just for the passing and missing tests
+    # Write a new tests-with-issue-trackers file just for the passing and
+    # missing tests
     with open(testOutputDir+"/testsWithIssueTrackers.csv", 'w') as testsWithIssueTrackerFile:
       testsWithIssueTrackerFile.write('''site, buildName, testname, issue_tracker_url, issue_tracker
 cee-rhel6, Trilinos-atdm-cee-rhel6-clang-opt-serial, MueLu_UnitTestsBlockedEpetra_MPI_1, https://github.com/trilinos/Trilinos/issues/3640, #3640

--- a/test/ci_support/cdash_analyze_and_report_UnitTests.py
+++ b/test/ci_support/cdash_analyze_and_report_UnitTests.py
@@ -130,6 +130,31 @@ def writeNonpassTestsDictListToCDashJsonFile(testsLOD, testOutputDir,
   writeTestsDictListToCDashJsonFile(testsLOD, testOutputDir, testsJsonRelFilePath)
 
 
+# Find an expected build from str list given 'site' and 'buildname'
+#
+def indexOfExpectedBuildFromCsvStrList(expectedBuildsStrList, group, site, buildname):
+  group_site_buildname = group+", "+site+", "+buildname
+  index = 0
+  for expectedBuildLine in expectedBuildsStrList:
+    if expectedBuildLine.find(group_site_buildname) == 0:
+      return index
+    index += 1
+  return -1
+
+
+# Remove a site and build name from the list of expected build from a CSV file
+# string array.
+#
+def removeExpectedBuildFromCsvStrList(expectedBuildsStrList, group, site, buildname):
+  index = indexOfExpectedBuildFromCsvStrList(expectedBuildsStrList,
+    group, site, buildname)
+  if index >= 0:
+    del expectedBuildsStrList[index]
+  else:
+    raise Exception("Error, could not find 'site'='"+site+\
+      ", 'buildname'='"+buildname+"'!")
+
+
 # Run a test case involving the cdash_analyze_and_report.py
 #
 # This function runs a test case involving a the script
@@ -861,8 +886,8 @@ class test_cdash_analyze_and_report(unittest.TestCase):
   # Add some missing builds, some builds with configure failuires, and builds
   # with build failures
   #
-  # Here we just a couple of new builds to the file expectedBuilds.csv that
-  # will become missing expected builds and we modfiy the dicts for a few
+  # Here we just add a couple of new builds to the file expectedBuilds.csv
+  # that will become missing expected builds and we modfiy the dicts for a few
   # builds to change them from passing to failing.
   #
   def test_bm_2_c_1_b_2_twoif_12_twif_9(self):
@@ -1707,6 +1732,109 @@ cee-rhel6, Trilinos-atdm-cee-rhel6-gnu-4.9.3-opt-serial, PanzerAdaptersIOSS_tIOS
     self.assertEqual(testDict['cdash_testing_day'], u'2018-10-28')
     self.assertEqual(testDict['test_history_list'][0]['buildstarttime'],
       '2018-10-26T12:00:00 UTC')
+
+
+  # Pass in a reduced set of expected builds and filter out builds and tests
+  # that don't match those expected builds.
+  #
+  # This test removes a couple of different expected builds.
+  #
+  def test_twoif_2_twif_4_filter_based_on_expected_builds(self):
+
+    testCaseName = "test_twoif_2_twif_4_filter_based_on_expected_builds"
+
+    testOutputDir = cdash_analyze_and_report_setup_test_dir(testCaseName)
+
+    # Remove some expected builds
+    expectedBuildsFilePath = testOutputDir+"/expectedBuilds.csv"
+    with open(expectedBuildsFilePath, 'r') as expectedBuildsFile:
+      expectedBuildsStrList = expectedBuildsFile.readlines()
+    removeExpectedBuildFromCsvStrList(expectedBuildsStrList,
+      "Specialized", "cee-rhel6", "Trilinos-atdm-cee-rhel6-clang-opt-serial")
+    removeExpectedBuildFromCsvStrList(expectedBuildsStrList,
+      "Specialized", "mutrino", "Trilinos-atdm-mutrino-intel-opt-openmp-KNL")
+    with open(expectedBuildsFilePath, 'w') as expectedBuildsFile:
+      expectedBuildsFile.write("".join(expectedBuildsStrList))
+
+    cdash_analyze_and_report_run_case(
+      self,
+      testCaseName,
+      [ "--print-details=on", # grep for verbose output
+        "--filter-out-builds-and-tests-not-matching-expected-builds=on",
+        ],
+      1,
+      "FAILED (twoif=2, twif=4): ProjectName Nightly Builds on 2018-10-28",
+      [
+        "[*][*][*] Query and analyze CDash results for ProjectName Nightly Builds for testing day 2018-10-28",
+        "Num expected builds = 4",
+        "Num tests with issue trackers read from CSV file = 9",
+        "Num tests with issue trackers matching expected builds = 4",
+        "Num tests with issue trackers = 4",
+        "Num builds downloaded from CDash = 6",
+        "Num builds matching expected builds = 4",
+        "Num builds = 4",
+        "Num nonpassing tests direct from CDash query = 21",
+        "Num nonpassing tests matching expected builds = 6",
+        "Num nonpassing tests = 6",
+        "Num nonpassing tests after removing duplicate tests = 6",
+        "Num nonpassing tests without issue trackers = 2",
+        "Num nonpassing tests with issue trackers = 4",
+        "Num nonpassing tests without issue trackers Failed = 2",
+        "Num nonpassing tests without issue trackers Not Run = 0",
+        "Num nonpassing tests with issue trackers Failed = 4",
+        "Num nonpassing tests with issue trackers Not Run = 0",
+        "Num tests with issue trackers gross passing or missing = 0",
+
+        "Builds Missing: bm=0",
+        "Builds with Configure Failures: cf=0",
+        "Builds with Build Failures: bf=0",
+        "Num tests with issue trackers Passed = 0",
+        "Num tests with issue trackers Missing = 0",
+
+        "Tests without issue trackers Failed: twoif=2",
+        "Getting 30 days of history for Teko_testdriver_tpetra_MPI_1 in the build Trilinos-atdm-waterman-cuda-9.2-release-debug on waterman",
+        "Getting 30 days of history for Teko_testdriver_tpetra_MPI_4 in the build Trilinos-atdm-waterman-cuda-9.2-release-debug on waterman",
+
+        "Tests with issue trackers Failed: twif=4",
+        "Getting 30 days of history for PanzerAdaptersIOSS_tIOSSConnManager2_MPI_2 in the build Trilinos-atdm-cee-rhel6-gnu-4.9.3-opt-serial on cee-rhel6",
+        "Getting 30 days of history for PanzerAdaptersIOSS_tIOSSConnManager2_MPI_2 in the build Trilinos-atdm-cee-rhel6-intel-opt-serial on cee-rhel6",
+        "Getting 30 days of history for PanzerAdaptersIOSS_tIOSSConnManager3_MPI_3 in the build Trilinos-atdm-cee-rhel6-gnu-4.9.3-opt-serial on cee-rhel6",
+        "Getting 30 days of history for PanzerAdaptersIOSS_tIOSSConnManager3_MPI_3 in the build Trilinos-atdm-cee-rhel6-intel-opt-serial on cee-rhel6",
+        ],
+      [
+        # Top title
+        "<h2>Build and Test results for ProjectName Nightly Builds on 2018-10-28</h2>",
+
+        # First paragraph with with links to build and nonpassing tests results on cdsah
+        "<p>",
+        "<a href=\"https://something[.]com/cdash/index[.]php[?]project=ProjectName&date=2018-10-28&builds_filters\">Builds on CDash</a> [(]num/expected=4/4[)]<br>",
+        "<a href=\"https://something[.]com/cdash/queryTests[.]php[?]project=ProjectName&date=2018-10-28&nonpasssing_tests_filters\">Non-passing Tests on CDash</a> [(]num=6[)]<br>",
+        "</p>",
+
+        # Second paragraph with listing of different types of tables below
+        "<p>",
+        "<font color=\"red\">Tests without issue trackers Failed: twoif=2</font><br>",
+        "Tests with issue trackers Failed: twif=4<br>",
+        "</p>",
+
+        # twoif table
+        "<h3><font color=\"red\">Tests without issue trackers Failed [(]limited to 10[)]: twoif=2</font></h3>",
+        #"Trilinos-atdm-waterman-cuda-9[.]2-release-debug.*Teko_testdriver_tpetra_MPI_1.*waterman",
+        #"Trilinos-atdm-waterman-cuda-9[.]2-release-debug.*Teko_testdriver_tpetra_MPI_4.*waterman",
+        # Can't seem to match above for some reason?
+
+        # twif table
+        "<h3>Tests with issue trackers Failed: twif=4</h3>",
+        #"Trilinos-atdm-cee-rhel6-gnu-4[.]9[.]3-opt-serial.*PanzerAdaptersIOSS_tIOSSConnManager2_MPI_2.*cee-rhel6",
+        #"Trilinos-atdm-cee-rhel6-intel-opt-serial.*PanzerAdaptersIOSS_tIOSSConnManager2_MPI_2.*cee-rhel6",
+        #"Trilinos-atdm-cee-rhel6-gnu-4[.]9[.]3-opt-serial.*PanzerAdaptersIOSS_tIOSSConnManager3_MPI_3.*cee-rhel6",
+        #"Trilinos-atdm-cee-rhel6-intel-opt-serial.*PanzerAdaptersIOSS_tIOSSConnManager3_MPI_3.*cee-rhel6",
+        # Can't seem to match above for some reason?
+
+        ],
+      #verbose=True,
+      #debugPrint=True,
+      )
 
 
 #

--- a/tribits/ci_support/CDashQueryAnalyzeReport.py
+++ b/tribits/ci_support/CDashQueryAnalyzeReport.py
@@ -1235,6 +1235,9 @@ class AddIssueTrackerInfoToTestDictFunctor(object):
 #   unique.  The 'group' field is ignored (because cdash/queryTests.php does
 #   not give the 'group' of each test).
 #
+# Returns the tuple (testsWithIssueTrackersMatchingExpectedBuildsLOD,
+# testsWithIssueTrackersNotMatchingExpectedBuildsLOD).
+#
 def splitTestsOnMatchExpectedBuilds( testsWithIssueTrackersLOD,
     testToExpectedBuildsSLOD,
   ):
@@ -1796,19 +1799,6 @@ class AddTestHistoryToTestDictFunctor(object):
 
     # Return the updated test dict with the new fields
     return testDict
-
-
-def filterLOD(LOD, filterLOD, LODkey, filterLODkey=None):
-  newLOD = []
-  if not filterLODkey:
-    filterLODkey = LODkey
-
-  for filt in filterLOD:
-    for entry in LOD:
-      if entry[LODkey] == filt[filterLODkey]:
-        newLOD.append(entry)
-
-  return newLOD
 
 
 def setTestDictAsMissing(testDict):

--- a/tribits/ci_support/CDashQueryAnalyzeReport.py
+++ b/tribits/ci_support/CDashQueryAnalyzeReport.py
@@ -1224,8 +1224,8 @@ class AddIssueTrackerInfoToTestDictFunctor(object):
     return testDict_inout
 
 
-# Split the a list of Test Dicts based on if they match the set of expected
-# builds or not.
+# Split a list of Test Dicts based on if they match the set of expected builds
+# or not.
 #
 # testsWithIssueTrackersLOD [in]: List of dicts of tests with issue trackers.
 #   Here, only the fields 'site', 'buildName', and 'testname' are significant.

--- a/tribits/ci_support/cdash_analyze_and_report.py
+++ b/tribits/ci_support/cdash_analyze_and_report.py
@@ -484,7 +484,7 @@ if __name__ == '__main__':
 
     # Assert that the list of tests with issue trackers matches the list of
     # expected builds
-    (allTestsMatch, errMsg) = CDQAR.testsWithIssueTrackersMatchExpectedBuilds(
+    (allTestsMatch, errMsg) = CDQAR.doTestsWithIssueTrackersMatchExpectedBuilds(
       testsWithIssueTrackersLOD, testsToExpectedBuildsSLOD)
     if not allTestsMatch:
       raise Exception(errMsg)

--- a/tribits/ci_support/cdash_analyze_and_report.py
+++ b/tribits/ci_support/cdash_analyze_and_report.py
@@ -450,7 +450,7 @@ if __name__ == '__main__':
       expectedBuildsLOD = []
     print("\nNum expected builds = "+str(len(expectedBuildsLOD)))
 
-    # Create a SearchableListOfDict object to help look up expectged builds
+    # Create a SearchableListOfDict object to help look up expected builds
     # given a build dict by key/value pairs 'group', 'site', and 'buildname'
     # (requires unique builds with these key/value pairs)
     expectedBuildsSLOD = CDQAR.createSearchableListOfBuilds(expectedBuildsLOD)


### PR DESCRIPTION
This adds the  `cdash_analyze_and_report.py` argument `--filter-out-builds-and-tests-not-matching-expected-builds=[on|off]` (default `off`).  It also correctly filters builds and tests based on the expected builds list considering both 'site' and 'buildname'/'buildName' fields.  And it adds auto filtering of tests-with-issue-trackers based on expected builds.

A strong new system-level test was added to make sure this works as it should (and strong unit tests for the pieces).

@e10harvey, this PR is against the branch in your PR https://github.com/TriBITSPub/TriBITS/pull/347.  Please review and approve this PR and then I can approve https://github.com/TriBITSPub/TriBITS/pull/347.
